### PR TITLE
Configure image to use bind mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM solr:7.7-alpine
 
-COPY solr /var/solr
+ENV SOLR_HOME /var/solr
+ENV GEO_CORE /var/geoweb
+
 USER root
-RUN chown -R solr:solr /var/solr
-USER solr
+COPY solr $GEO_CORE
+COPY entrypoint.sh /usr/local/bin/
+RUN mkdir -p $SOLR_HOME
+RUN chown -R solr:solr $GEO_CORE $SOLR_HOME /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["solr-foreground"]

--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,19 @@ help: ## Print this message
 		/^[-_[:alpha:]]+:.?*##/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 dist: ## Build docker image
-	docker build -t $(ECR_REGISTRY)/geosolr-stage:latest \
-		-t $(ECR_REGISTRY)/geosolr-stage:`git describe --always` \
-		-t geosolr .
+	docker build -t $(ECR_REGISTRY)/solr-stage:latest \
+		-t $(ECR_REGISTRY)/solr-stage:`git describe --always` \
+		-t solr .
 
 publish: ## Push and tag the latest image (use `make dist && make publish`)
 	$$(aws ecr get-login --no-include-email --region us-east-1)
-	docker push $(ECR_REGISTRY)/geosolr-stage:latest
-	docker push $(ECR_REGISTRY)/geosolr-stage:`git describe --always`
+	docker push $(ECR_REGISTRY)/solr-stage:latest
+	docker push $(ECR_REGISTRY)/solr-stage:`git describe --always`
 
 promote: ## Promote the current staging build to production
 	$$(aws ecr get-login --no-include-email --region us-east-1)
-	docker pull $(ECR_REGISTRY)/geosolr-stage:latest
-	docker tag $(ECR_REGISTRY)/geosolr-stage:latest $(ECR_REGISTRY)/geosolr-prod:latest
-	docker tag $(ECR_REGISTRY)/geosolr-stage:latest $(ECR_REGISTRY)/geosolr-prod:$(DATETIME)
-	docker push $(ECR_REGISTRY)/geosolr-prod:latest
-	docker push $(ECR_REGISTRY)/geosolr-prod:$(DATETIME)
+	docker pull $(ECR_REGISTRY)/solr-stage:latest
+	docker tag $(ECR_REGISTRY)/solr-stage:latest $(ECR_REGISTRY)/solr-prod:latest
+	docker tag $(ECR_REGISTRY)/solr-stage:latest $(ECR_REGISTRY)/solr-prod:$(DATETIME)
+	docker push $(ECR_REGISTRY)/solr-prod:latest
+	docker push $(ECR_REGISTRY)/solr-prod:$(DATETIME)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+
+cp -rf $GEO_CORE/* $SOLR_HOME
+chown -R solr:solr $SOLR_HOME
+
+exec gosu solr docker-entrypoint.sh "$@"


### PR DESCRIPTION
This sets up the Solr container to make use of the EFS bind mount. The
geoweb core gets copied to the bind mount at runtime, overriding any
existing files. This will allow changes in the core config to be
propagated to the EFS mount on container restart.